### PR TITLE
Add support for init containers in client and guacd deployments

### DIFF
--- a/charts/guacamole/templates/client-deployment.yaml
+++ b/charts/guacamole/templates/client-deployment.yaml
@@ -35,6 +35,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.client.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: guacamole-client
           {{- with .Values.securityContext }}

--- a/charts/guacamole/templates/guacd-deployment.yaml
+++ b/charts/guacamole/templates/guacd-deployment.yaml
@@ -35,6 +35,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.guacd.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: guacd
           {{- with .Values.securityContext }}

--- a/charts/guacamole/values.yaml
+++ b/charts/guacamole/values.yaml
@@ -526,6 +526,22 @@ client:
   # More information: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   affinity: {}
 
+  # Init containers for the client pod
+  # Useful for database initialization, secret fetching, or other pre-start tasks
+  # More information: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  initContainers: []
+  # - name: init-database
+  #   image: busybox:1.36
+  #   command: ['sh', '-c', 'echo "Waiting for database..." && sleep 10']
+  # - name: init-config
+  #   image: busybox:1.36
+  #   command: ['sh', '-c', 'cp /config/* /shared/']
+  #   volumeMounts:
+  #     - name: config
+  #       mountPath: /config
+  #     - name: shared
+  #       mountPath: /shared
+
 # Guacd Daemon configuration
 # The guacd daemon built from guacamole-server source with support for VNC, RDP, SSH, telnet, and Kubernetes
 # Handles the actual remote desktop protocol connections on behalf of the Guacamole web application
@@ -610,6 +626,17 @@ guacd:
   # Affinity rules for guacd pod assignment
   # More information: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   affinity: {}
+
+  # Init containers for the guacd pod
+  # Useful for waiting on dependencies or preparing shared storage
+  # More information: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  initContainers: []
+  # - name: init-recordings
+  #   image: busybox:1.36
+  #   command: ['sh', '-c', 'mkdir -p /recordings && chmod 1777 /recordings']
+  #   volumeMounts:
+  #     - name: recordings
+  #       mountPath: /recordings
 
 # Global configuration shared by both client and guacd deployments
 


### PR DESCRIPTION
Adds configurable init containers for both Guacamole client and guacd deployments, enabling pre-start tasks like waiting for dependencies or initializing shared storage.

Created with the help of Copilot.
Fixes #2 

### Changes
- **values.yaml**: Added `initContainers` array under both `client` and `guacd` sections
- **client-deployment.yaml / guacd-deployment.yaml**: Render init containers when configured
- **README.md**: Added documentation and usage examples

### Usage

```yaml
client:
  initContainers:
    - name: wait-for-database
      image: busybox:1.36
      command: ['sh', '-c', 'until nc -z postgres 5432; do sleep 2; done']

guacd:
  initContainers:
    - name: init-recordings
      image: busybox:1.36
      command: ['sh', '-c', 'mkdir -p /recordings']
      volumeMounts:
        - name: recordings
          mountPath: /recordings
```


